### PR TITLE
Use of index as key in a v-for directive to prevent following errors

### DIFF
--- a/src/views/Files.vue
+++ b/src/views/Files.vue
@@ -5,7 +5,7 @@
         <i class="material-icons">home</i>
       </router-link>
 
-      <span v-for="link in breadcrumbs" :key="link.name">
+      <span v-for="(link, index) in breadcrumbs" :key="index">
         <span class="chevron"><i class="material-icons">keyboard_arrow_right</i></span>
         <router-link :to="link.url">{{ link.name }}</router-link>
       </span>


### PR DESCRIPTION
Olá,

I recently used the filebrowser and ran into an issue which I try to solve by my PR. Unfortunately I was not really able to fully set up a development environment (runnig your go backend alongside the frontend) to debug the problem actually. So I try to explain what I discovered:

- Assuming a deeper folder structure like `/static/test/static/src/images/png` leads into duplicate folder names which are then used to index the `v-for` directive by using the `:key` directive (usually you get `console.warn` outputs from `Vue` itsself in a development build if you are doing so…)
- `Vue` itself recommends to use unique keys therefor, see [docs](https://vuejs.org/v2/guide/list.html#key)
- In your `Files.vue` located under `/src/views` you limit the breadcrumb count to a maximum of 4 by using ellipsis (`…`) [code reference](https://github.com/filebrowser/frontend/blob/master/src/views/Files.vue#L97)
- The combination of duplicate names and abbreviated breadcrumbs now leads into an error on back navigation by clicking on browser history's back button like in `chrome` at the upper left corner:

```
vue.esm.js:1717 TypeError: Cannot read property 'key' of undefined
    at dn (vue.esm.js:5370)
    at b (vue.esm.js:5752)
    at k (vue.esm.js:5840)
    at b (vue.esm.js:5726)
    at k (vue.esm.js:5840)
    at a.__patch__ (vue.esm.js:6000)
    at a.e._update (vue.esm.js:2647)
    at a.r (vue.esm.js:2765)
    at pa.get (vue.esm.js:3115)
    at pa.run (vue.esm.js:3192)
```

After that, you will need to do a full page reload to proceed working…

I did a screen to gif record to capture the procees to reproduce the bug:

![fb_bug](https://user-images.githubusercontent.com/11720107/41237803-bb510282-6d94-11e8-8f0f-c917bbd98a7d.gif)

I hope this will help to understand the problem!

Adeus!