### PR TITLE
Update 'Report issue' URL

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ Vue.prototype.$showError = function (error) {
     timeout: null,
     buttons: [
       Noty.button(i18n.t('buttons.reportIssue'), '', function () {
-        window.open('https://github.com/filebrowser/filebrowser/issues/new')
+        window.open('https://github.com/filebrowser/filebrowser/issues/new/choose')
       }),
       Noty.button(i18n.t('buttons.close'), '', function () {
         n.close()


### PR DESCRIPTION
After merging filebrowser/filebrowser#477, the URL needs to be updated so that users can choose the correct bug template. Otherwise an empty new issue is opened.