### PR TITLE
fix: remove spaces before command output

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -48,9 +48,7 @@
           </li>
         </ul>
 
-        <pre v-else-if="commands.length > 0">
-          <template v-for="c in commands">{{ c }}</template>
-        </pre>
+        <pre v-else-if="commands.length > 0"><template v-for="c in commands">{{ c }}</template></pre>
       </div>
       <p id="renew"><i class="material-icons spin">autorenew</i></p>
     </div>


### PR DESCRIPTION
The first line of output of the execution of a command is shown with additional margin:
```
        -rwxrwxr-x. 1 user user 14 Aug 20 18:41 ./atest.md
-rwxrwxr-x. 1 user user 21 Aug 20 18:41 ./anothertest.txt
```
This PR fixes it by removing spaces in the HTML source.