### PR TITLE
Fix/fast change directory

### DIFF
--- a/src/views/Files.vue
+++ b/src/views/Files.vue
@@ -144,7 +144,7 @@ export default {
 
       api.fetch(url)
         .then((req) => {
-          if (window.location.pathname !== req.url) return
+          if (this.$store.state.baseURL + req.url !== window.location.pathname) return
           if (!url.endsWith('/') && req.url.endsWith('/')) {
             window.history.replaceState(window.history.state, document.title, window.location.pathname + '/')
           }

--- a/src/views/Files.vue
+++ b/src/views/Files.vue
@@ -144,6 +144,7 @@ export default {
 
       api.fetch(url)
         .then((req) => {
+          if (window.location.pathname !== req.url) return
           if (!url.endsWith('/') && req.url.endsWith('/')) {
             window.history.replaceState(window.history.state, document.title, window.location.pathname + '/')
           }


### PR DESCRIPTION
Fix filebrowser/filebrowser#561: Switching directory too fast make the content overwritten by last directory. 
Promise is an asynchronous operation, the last promise may call .then function after current directory has been changed. 
