### PR TITLE
Fix misleading prompt in zh-cn

### DIFF
--- a/src/i18n/zh-cn.yaml
+++ b/src/i18n/zh-cn.yaml
@@ -178,7 +178,7 @@ search:
   pressToSearch: 按回车键搜索。
   search: 搜索...
   searchOrCommand: 搜索或者执行命令(Linux 代码)...
-  searchOrSupportedCommand: 搜索或使用您可以使用的命令(一次只能执行一个命令)：
+  searchOrSupportedCommand: 搜索或加入"$"前缀以使用其中一个您可以使用的命令：
   type: 键入并按回车键进行搜索。
   types: 类型
   video: 视频


### PR DESCRIPTION
It seems that the behaviour and the prompt in English of executing a command had been changed, but the translation in zh-cn was still the previous one, which made me confused for a while until I changed the language.

Not sure whether to use one or two pairs of single quote here, so I used a pair of double quote.