### PR TITLE
Send message to user if file upload is onprogress before closing the tab

### DIFF
--- a/src/api/files.js
+++ b/src/api/files.js
@@ -94,7 +94,14 @@ export async function post (url, content = '', overwrite = false, onupload) {
       request.upload.onprogress = onupload
     }
 
+    // Send a message to user before closing the tab during file upload
+    window.onbeforeunload = () => {
+      return "uploading!!!"
+    };
+
     request.onload = () => {
+      // Upload is done no more message before closing the tab 
+      window.onbeforeunload = null;
       if (request.status === 200) {
         resolve(request.responseText)
       } else if (request.status === 409) {


### PR DESCRIPTION
Impatient users or users which do not see the progress bar may refresh the page to see there file grow.
I think the package should advertise the user that he is about to cancel his upload.